### PR TITLE
Allow passing a platform argument to generate graph for CLJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ from a Clojure project directory. This outputs a file `ns-dep-graph.png` showing
 the internal namespace dependencies of the project's `.clj` sources.
 Dependencies on external namespaces, say `clojure.java.io`, are not shown.
 
+You can also pass an optional platform argument to generate a graph for ClojureScript
+
+    lein ns-dep-graph :cljs # or
+    lein ns-dep-graph :clj
+
+
 ## Examples
 
 Below is the namespace dependency graph obtained for

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject lein-ns-dep-graph "0.1.1-SNAPSHOT"
+(defproject lein-ns-dep-graph "0.2.0-SNAPSHOT"
   :description "Show namespace dependencies of project sources as a graph."
   :url "https://github.com/hilverd/lein-ns-dep-graph"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[org.clojure/tools.namespace "0.2.3"]
+  :dependencies [[org.clojure/tools.namespace "0.3.0-alpha3"]
                  [rhizome "0.1.8"]])


### PR DESCRIPTION
This required an upgrade to tools.namespace too. The new version of
tools.namespace requires tools.reader 0.10.0, but when I was testing
this there was another version of tools.reader coming from somewhere
which was conflicting. I've opened a ticket against Leiningen to upgrade
their clj-http dependency as I suspect it could be this one.

I've vendored read-file-ns-decl so that it prints out exceptions that
get thrown. I'm not 100% sure if this is the right option, but I don't
like how it swallows all exceptions.

Fixes #1
