### PR TITLE
Add option to visualise only nodes that have some transitive parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ Dependencies on external namespaces, say `clojure.java.io`, are not shown.
 
 You can also pass an optional platform argument to generate a graph for ClojureScript
 
-    lein ns-dep-graph :cljs # or
-    lein ns-dep-graph :clj
+    lein ns-dep-graph -platform :cljs # or
+    lein ns-dep-graph -platform :clj
+
+You can also pass an option parents argument, to generate a graph showing only the
+nodes that have (one of) those namespaces as their transitive parent:
+
+    lein ns-dep-graph -parents [my-app.module.b.core]
 
 
 ## Examples


### PR DESCRIPTION
Hi @hilverd,

Thanks for the plugin. I wanted to have only a part of the complete system shown. More specifically, showing everything from a certain namespace and deeper. Therefore I added the `-parents` option. Maybe you like it. Maybe you don't, that's fine as well.